### PR TITLE
chore: release v0.1.1

### DIFF
--- a/.changeset/test-release-workflow.md
+++ b/.changeset/test-release-workflow.md
@@ -1,7 +1,0 @@
----
-"claude-codex": patch
----
-
-Test automated release workflow with GitHub releases
-
-This is a test release to verify that the complete automated workflow now works including NPM publishing, Git tag creation, and GitHub release generation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # claude-codex
 
+## 0.1.1
+
+### Patch Changes
+
+- 2f9a8ca: Test automated release workflow with GitHub releases
+
+  This is a test release to verify that the complete automated workflow now works including NPM publishing, Git tag creation, and GitHub release generation.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-codex",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Automation scripts powered by Claude Code SDK",
   "type": "module",
   "main": "dist/lib.js",


### PR DESCRIPTION
Release PR created by changesets workflow

This PR contains:
- Version bump from 0.1.0 → 0.1.1  
- Updated CHANGELOG.md
- Consumed pending changesets

Merging this PR will trigger automatic NPM publish and GitHub release creation.