### PR TITLE
Fix: Template path issues after refactor

### DIFF
--- a/src/config/initialization.ts
+++ b/src/config/initialization.ts
@@ -6,7 +6,7 @@ import { pathExists } from '~/shared/utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const TEMPLATES_DIR = join(__dirname, '..', 'templates');
+const TEMPLATES_DIR = join(__dirname, 'templates');
 
 export interface InitOptions {
   force?: boolean;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,3 +1,4 @@
+import { cp } from 'node:fs/promises';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
@@ -29,7 +30,11 @@ export default defineConfig({
     '@anthropic-ai/claude-code', // Keep external for user's claude-code installation
   ],
 
-  // No banner needed - the entry file already has shebang
+  // Copy templates after build
+  onSuccess: async () => {
+    await cp('src/templates', 'dist/templates', { recursive: true });
+    console.log('✅ Templates copied to dist/templates');
+  },
 
   // Platform
   platform: 'node',


### PR DESCRIPTION
## Summary
- Fixed template path resolution issues caused by recent refactor
- Templates are now properly copied to dist/ during build process
- Init command works correctly when installed via npm/npx

## Changes
- **Build Process**: Added template copying to `tsup.config.ts` using `onSuccess` hook
- **Path Resolution**: Fixed `src/config/initialization.ts` to use correct bundled path
- **Distribution**: Templates now included in npm package via existing dist/ entry

## Test Plan
- [x] Build process successfully copies templates to `dist/templates/`
- [x] Init command creates all config files: `node dist/index.js init --force`
- [x] All tests pass (183 passed, 11 skipped)
- [x] Code quality checks pass
- [x] Manual verification of template file creation

## Root Cause
After the refactor, templates moved to `src/templates/` but weren't included in the npm package. The runtime code expected templates at `dist/templates/` but they didn't exist in the built package.

🤖 Generated with [Claude Code](https://claude.ai/code)